### PR TITLE
Require Cloudflare runtime secrets for /api/decode with local fallbacks and update deployment docs

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -9,9 +9,16 @@ This project is configured for Cloudflare Pages (Static).
    - **Build Command**: `npm run build`
    - **Output Directory**: `dist`
 3. **Environment Variables**:
-   - Add your Supabase credentials in the Cloudflare Pages dashboard:
+   - Add required variables in the Cloudflare Pages dashboard:
      - `PUBLIC_SUPABASE_URL`
      - `PUBLIC_SUPABASE_ANON_KEY`
+     - `SUPABASE_SERVICE_ROLE_KEY`
+     - `OPENROUTER_API_KEY`
+   - For secrets in Workers/Pages, prefer encrypted secrets via Wrangler:
+     - `npx wrangler secret put OPENROUTER_API_KEY`
+     - `npx wrangler secret put SUPABASE_SERVICE_ROLE_KEY`
+   - **Important**: For production, `/api/decode` expects Cloudflare runtime bindings. Local fallbacks are only for development.
+   - In Cloudflare dashboard, set these values in the **same environment** you are testing (Production or Preview).
 
 ## Vercel
 1. **Import Project**: Select your repository.
@@ -19,7 +26,7 @@ This project is configured for Cloudflare Pages (Static).
 3. **Build Command**: `npm run build` (or default).
 4. **Output Directory**: `dist` (default).
 5. **Environment Variables**:
-   - Add `PUBLIC_SUPABASE_URL` and `PUBLIC_SUPABASE_ANON_KEY`.
+   - Add `PUBLIC_SUPABASE_URL`, `PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, and `OPENROUTER_API_KEY`.
 
 ## Local Development
 - Run `npm run dev` to start the Astro dev server.

--- a/src/pages/api/decode.ts
+++ b/src/pages/api/decode.ts
@@ -18,29 +18,50 @@ function arrayBufferToBase64(buffer: ArrayBuffer) {
   let binary = '';
   const bytes = new Uint8Array(buffer);
   const len = bytes.byteLength;
+
   for (let i = 0; i < len; i++) {
     binary += String.fromCharCode(bytes[i]);
   }
+
   return btoa(binary);
 }
 
-function resolveDecodeEnv(locals: App.Locals): { env: DecodeEnv | null; missing: string[]; source: string } {
+function resolveDecodeEnv(
+  locals: App.Locals
+): { env: DecodeEnv | null; missing: string[]; source: string } {
   const runtimeEnv = locals?.runtime?.env;
   const isDev = import.meta.env.DEV;
 
   // In Cloudflare deployment we require real runtime bindings.
   // process/import.meta fallbacks are allowed only in local development.
   const candidateEnv: Record<string, string | undefined> = {
-    OPENROUTER_API_KEY: runtimeEnv?.OPENROUTER_API_KEY || (isDev ? process.env.OPENROUTER_API_KEY || import.meta.env.OPENROUTER_API_KEY : undefined),
-    PUBLIC_SUPABASE_URL: runtimeEnv?.PUBLIC_SUPABASE_URL || (isDev ? process.env.PUBLIC_SUPABASE_URL || import.meta.env.PUBLIC_SUPABASE_URL : undefined),
-    SUPABASE_SERVICE_ROLE_KEY: runtimeEnv?.SUPABASE_SERVICE_ROLE_KEY || (isDev ? process.env.SUPABASE_SERVICE_ROLE_KEY || import.meta.env.SUPABASE_SERVICE_ROLE_KEY : undefined),
+    OPENROUTER_API_KEY:
+      runtimeEnv?.OPENROUTER_API_KEY ||
+      (isDev
+        ? process.env.OPENROUTER_API_KEY || import.meta.env.OPENROUTER_API_KEY
+        : undefined),
+    PUBLIC_SUPABASE_URL:
+      runtimeEnv?.PUBLIC_SUPABASE_URL ||
+      (isDev
+        ? process.env.PUBLIC_SUPABASE_URL || import.meta.env.PUBLIC_SUPABASE_URL
+        : undefined),
+    SUPABASE_SERVICE_ROLE_KEY:
+      runtimeEnv?.SUPABASE_SERVICE_ROLE_KEY ||
+      (isDev
+        ? process.env.SUPABASE_SERVICE_ROLE_KEY ||
+          import.meta.env.SUPABASE_SERVICE_ROLE_KEY
+        : undefined),
   };
 
   const missing = Object.entries(candidateEnv)
     .filter(([, value]) => !value)
     .map(([key]) => key);
 
-  const source = runtimeEnv ? 'cloudflare_runtime' : (isDev ? 'local_dev_fallback' : 'missing_cloudflare_runtime');
+  const source = runtimeEnv
+    ? 'cloudflare_runtime'
+    : isDev
+      ? 'local_dev_fallback'
+      : 'missing_cloudflare_runtime';
 
   if (missing.length > 0) {
     return { env: null, missing, source };
@@ -61,7 +82,11 @@ export const POST: APIRoute = async ({ request, locals }) => {
             step: 'resolve_environment',
             source,
             runtimeEnvAvailable: !!locals?.runtime?.env,
-            expectedBindings: ['OPENROUTER_API_KEY', 'PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'],
+            expectedBindings: [
+              'OPENROUTER_API_KEY',
+              'PUBLIC_SUPABASE_URL',
+              'SUPABASE_SERVICE_ROLE_KEY',
+            ],
             hint: 'Set variables/secrets in Cloudflare Pages/Workers project settings for this environment (Production/Preview).',
             timestamp: new Date().toISOString(),
           },
@@ -74,15 +99,24 @@ export const POST: APIRoute = async ({ request, locals }) => {
     const imageFile = formData.get('image');
 
     if (!imageFile || !(imageFile instanceof Blob)) {
-      return new Response(JSON.stringify({ error: 'No valid image provided' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      return new Response(JSON.stringify({ error: 'No valid image provided' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
 
     if (!ALLOWED_MIME_TYPES.includes(imageFile.type)) {
-      return new Response(JSON.stringify({ error: 'Unsupported file type' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      return new Response(JSON.stringify({ error: 'Unsupported file type' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
 
     if (imageFile.size > MAX_FILE_SIZE) {
-      return new Response(JSON.stringify({ error: 'File too large (max 5MB)' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      return new Response(JSON.stringify({ error: 'File too large (max 5MB)' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
 
     const arrayBuffer = await imageFile.arrayBuffer();
@@ -91,15 +125,25 @@ export const POST: APIRoute = async ({ request, locals }) => {
     const clientAddress = request.headers.get('cf-connecting-ip') || 'unknown';
     const identityKey = `ip_${clientAddress}`;
 
-    const identityHashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(identityKey));
-    const finalIdentityKey = Array.from(new Uint8Array(identityHashBuffer)).map(b => b.toString(16).padStart(2, '0')).join('');
+    const identityHashBuffer = await crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode(identityKey)
+    );
+    const finalIdentityKey = Array.from(new Uint8Array(identityHashBuffer))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
 
     // 2. Hash Image
     const hashBuffer = await crypto.subtle.digest('SHA-256', arrayBuffer);
-    const hashHex = Array.from(new Uint8Array(hashBuffer)).map(b => b.toString(16).padStart(2, '0')).join('');
+    const hashHex = Array.from(new Uint8Array(hashBuffer))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
 
     // Supabase initialization
-    const supabase = createClient(env.PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+    const supabase = createClient(
+      env.PUBLIC_SUPABASE_URL,
+      env.SUPABASE_SERVICE_ROLE_KEY
+    );
 
     // 3. Check Cache
     const { data: cachedResult } = await supabase
@@ -110,16 +154,23 @@ export const POST: APIRoute = async ({ request, locals }) => {
       .single();
 
     if (cachedResult && cachedResult.result_json) {
-      return new Response(JSON.stringify({
-        status: 'cached',
-        result: cachedResult.result_json,
-        message: 'Returning existing result for this image'
-      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      return new Response(
+        JSON.stringify({
+          status: 'cached',
+          result: cachedResult.result_json,
+          message: 'Returning existing result for this image',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
     }
 
     // 4. Check Quota
     const now = new Date();
-    const windowStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString();
+    const windowStart = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate()
+    ).toISOString();
 
     const { data: quotaRow } = await supabase
       .from('usage_windows')
@@ -129,77 +180,95 @@ export const POST: APIRoute = async ({ request, locals }) => {
       .maybeSingle();
 
     if (quotaRow && quotaRow.successful_runs >= MAX_RUNS_PER_WINDOW) {
-      return new Response(JSON.stringify({
-        error: 'You have reached your 3-analysis limit for today',
-        status: 'quota_exceeded'
-      }), { status: 429, headers: { 'Content-Type': 'application/json' } });
+      return new Response(
+        JSON.stringify({
+          error: 'You have reached your 3-analysis limit for today',
+          status: 'quota_exceeded',
+        }),
+        { status: 429, headers: { 'Content-Type': 'application/json' } }
+      );
     }
 
     if (!quotaRow) {
       await supabase.from('usage_windows').insert({
         identity_key: finalIdentityKey,
         window_start: windowStart,
-        successful_runs: 0
+        successful_runs: 0,
       });
     }
 
-    const { data: jobData } = await supabase.from('analysis_jobs').insert({
-      identity_key: finalIdentityKey,
-      image_hash: hashHex,
-      prompt_version: PROMPT_VERSION,
-      status: 'processing'
-    }).select('id').single();
+    const { data: jobData } = await supabase
+      .from('analysis_jobs')
+      .insert({
+        identity_key: finalIdentityKey,
+        image_hash: hashHex,
+        prompt_version: PROMPT_VERSION,
+        status: 'processing',
+      })
+      .select('id')
+      .single();
 
     // 5. Call OpenRouter API
     const base64Image = arrayBufferToBase64(arrayBuffer);
 
     try {
-      const aiResponse = await fetch('https://openrouter.ai/api/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${env.OPENROUTER_API_KEY}`,
-          'HTTP-Referer': 'https://crackingwall.com',
-          'X-Title': 'CrackingWall Analysis'
-        },
-        body: JSON.stringify({
-          model: 'qwen/qwen2.5-vl-32b-instruct',
-          messages: [
-            {
-              role: 'user',
-              content: [
-                { type: 'text', text: PROMPT_IMAGE_ANALYSIS },
-                {
-                  type: 'image_url',
-                  image_url: {
-                    url: `data:${imageFile.type};base64,${base64Image}`
-                  }
-                }
-              ]
-            }
-          ],
-          response_format: { type: 'json_object' }
-        })
-      });
+      const aiResponse = await fetch(
+        'https://openrouter.ai/api/v1/chat/completions',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${env.OPENROUTER_API_KEY}`,
+            'HTTP-Referer': 'https://crackingwall.com',
+            'X-Title': 'CrackingWall Analysis',
+          },
+          body: JSON.stringify({
+            model: 'qwen/qwen2.5-vl-32b-instruct',
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  { type: 'text', text: PROMPT_IMAGE_ANALYSIS },
+                  {
+                    type: 'image_url',
+                    image_url: {
+                      url: `data:${imageFile.type};base64,${base64Image}`,
+                    },
+                  },
+                ],
+              },
+            ],
+            response_format: { type: 'json_object' },
+          }),
+        }
+      );
 
       const responseText = await aiResponse.text();
       let aiData;
+
       try {
         aiData = responseText ? JSON.parse(responseText) : {};
-      } catch (e) {
-        throw new Error(`AI response was not valid JSON: ${responseText.substring(0, 100)}`);
+      } catch {
+        throw new Error(
+          `AI response was not valid JSON: ${responseText.substring(0, 100)}`
+        );
       }
 
       if (!aiResponse.ok) {
-        const upstreamMessage = aiData.error?.message || `AI request failed with status ${aiResponse.status}`;
-        const normalizedMessage = aiResponse.status === 401
-          ? 'OpenRouter rejected the API key (401). Verify OPENROUTER_API_KEY in Cloudflare secrets.'
-          : upstreamMessage;
+        const upstreamMessage =
+          aiData.error?.message ||
+          `AI request failed with status ${aiResponse.status}`;
+
+        const normalizedMessage =
+          aiResponse.status === 401
+            ? 'OpenRouter rejected the API key (401). Verify OPENROUTER_API_KEY in Cloudflare secrets.'
+            : upstreamMessage;
+
         throw new Error(normalizedMessage);
       }
 
       if (!aiData.choices || !aiData.choices[0]) {
-        throw new Error('AI returned no results. Data: ' + JSON.stringify(aiData));
+        throw new Error(`AI returned no results. Data: ${JSON.stringify(aiData)}`);
       }
 
       const generatedText = aiData.choices[0].message.content;
@@ -207,11 +276,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
       await supabase.rpc('increment_successful_runs', {
         p_identity_key: finalIdentityKey,
-        p_window_start: windowStart
+        p_window_start: windowStart,
       });
 
       const runs = (quotaRow ? quotaRow.successful_runs : 0) + 1;
-      await supabase.from('usage_windows')
+      await supabase
+        .from('usage_windows')
         .update({ successful_runs: runs })
         .eq('identity_key', finalIdentityKey)
         .eq('window_start', windowStart);
@@ -219,52 +289,66 @@ export const POST: APIRoute = async ({ request, locals }) => {
       await supabase.from('image_cache').insert({
         image_hash: hashHex,
         prompt_version: PROMPT_VERSION,
-        result_json: parsedJson
+        result_json: parsedJson,
       });
 
       if (jobData) {
-        await supabase.from('analysis_jobs').update({
-          status: 'completed',
-          result_json: parsedJson,
-          finished_at: new Date().toISOString()
-        }).eq('id', jobData.id);
+        await supabase
+          .from('analysis_jobs')
+          .update({
+            status: 'completed',
+            result_json: parsedJson,
+            finished_at: new Date().toISOString(),
+          })
+          .eq('id', jobData.id);
       }
 
-      return new Response(JSON.stringify({
-        status: 'completed',
-        result: parsedJson
-      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
-
+      return new Response(
+        JSON.stringify({
+          status: 'completed',
+          result: parsedJson,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
     } catch (err: any) {
       if (jobData) {
-        await supabase.from('analysis_jobs').update({
-          status: 'failed',
-          error_code: err.message || 'AI_ERROR',
-          finished_at: new Date().toISOString()
-        }).eq('id', jobData.id);
+        await supabase
+          .from('analysis_jobs')
+          .update({
+            status: 'failed',
+            error_code: err.message || 'AI_ERROR',
+            finished_at: new Date().toISOString(),
+          })
+          .eq('id', jobData.id);
       }
-      return new Response(JSON.stringify({
-        error: 'Analysis failed: ' + err.message,
-        diagnostic: {
-          step: 'ai_fetch_processing',
-          timestamp: new Date().toISOString()
-        }
-      }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' }
-      });
-    }
 
+      return new Response(
+        JSON.stringify({
+          error: `Analysis failed: ${err.message}`,
+          diagnostic: {
+            step: 'ai_fetch_processing',
+            timestamp: new Date().toISOString(),
+          },
+        }),
+        {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    }
   } catch (err: any) {
-    return new Response(JSON.stringify({
-      error: 'Critical serverless error: ' + err.message,
-      diagnostic: {
-        step: 'initialize_request',
-        timestamp: new Date().toISOString()
+    return new Response(
+      JSON.stringify({
+        error: `Critical serverless error: ${err.message}`,
+        diagnostic: {
+          step: 'initialize_request',
+          timestamp: new Date().toISOString(),
+        },
+      }),
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
       }
-    }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' }
-    });
+    );
   }
 };

--- a/src/pages/api/decode.ts
+++ b/src/pages/api/decode.ts
@@ -8,6 +8,12 @@ const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 const MAX_RUNS_PER_WINDOW = 3;
 
+type DecodeEnv = {
+  OPENROUTER_API_KEY: string;
+  PUBLIC_SUPABASE_URL: string;
+  SUPABASE_SERVICE_ROLE_KEY: string;
+};
+
 function arrayBufferToBase64(buffer: ArrayBuffer) {
   let binary = '';
   const bytes = new Uint8Array(buffer);
@@ -18,38 +24,50 @@ function arrayBufferToBase64(buffer: ArrayBuffer) {
   return btoa(binary);
 }
 
-/** Strict Cloudflare runtime env accessor — throws if not available */
-function getRuntimeEnv(locals: App.Locals) {
-  const env = locals?.runtime?.env;
-  if (!env) throw new Error('Cloudflare runtime environment not available');
-  return env;
+function resolveDecodeEnv(locals: App.Locals): { env: DecodeEnv | null; missing: string[]; source: string } {
+  const runtimeEnv = locals?.runtime?.env;
+  const isDev = import.meta.env.DEV;
+
+  // In Cloudflare deployment we require real runtime bindings.
+  // process/import.meta fallbacks are allowed only in local development.
+  const candidateEnv: Record<string, string | undefined> = {
+    OPENROUTER_API_KEY: runtimeEnv?.OPENROUTER_API_KEY || (isDev ? process.env.OPENROUTER_API_KEY || import.meta.env.OPENROUTER_API_KEY : undefined),
+    PUBLIC_SUPABASE_URL: runtimeEnv?.PUBLIC_SUPABASE_URL || (isDev ? process.env.PUBLIC_SUPABASE_URL || import.meta.env.PUBLIC_SUPABASE_URL : undefined),
+    SUPABASE_SERVICE_ROLE_KEY: runtimeEnv?.SUPABASE_SERVICE_ROLE_KEY || (isDev ? process.env.SUPABASE_SERVICE_ROLE_KEY || import.meta.env.SUPABASE_SERVICE_ROLE_KEY : undefined),
+  };
+
+  const missing = Object.entries(candidateEnv)
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  const source = runtimeEnv ? 'cloudflare_runtime' : (isDev ? 'local_dev_fallback' : 'missing_cloudflare_runtime');
+
+  if (missing.length > 0) {
+    return { env: null, missing, source };
+  }
+
+  return { env: candidateEnv as DecodeEnv, missing: [], source };
 }
 
 export const POST: APIRoute = async ({ request, locals }) => {
   try {
-    // --- Strict runtime env access (no import.meta.env fallbacks for secrets) ---
-    const env = getRuntimeEnv(locals);
+    const { env, missing, source } = resolveDecodeEnv(locals);
 
-    // --- Temporary debug logs (remove after confirming env access) ---
-    console.log('Runtime env available:', !!locals?.runtime?.env);
-    console.log('OPENROUTER_API_KEY exists:', !!env.OPENROUTER_API_KEY);
-    console.log('PUBLIC_SUPABASE_URL exists:', !!env.PUBLIC_SUPABASE_URL);
-    console.log('SUPABASE_SERVICE_ROLE_KEY exists:', !!env.SUPABASE_SERVICE_ROLE_KEY);
-
-    // --- Early validation of all required env vars ---
-    const requiredEnvVars = [
-      'OPENROUTER_API_KEY',
-      'PUBLIC_SUPABASE_URL',
-      'SUPABASE_SERVICE_ROLE_KEY',
-    ];
-
-    for (const key of requiredEnvVars) {
-      if (!env[key]) {
-        return new Response(
-          JSON.stringify({ error: `Missing required env variable: ${key}` }),
-          { status: 500, headers: { 'Content-Type': 'application/json' } }
-        );
-      }
+    if (!env) {
+      return new Response(
+        JSON.stringify({
+          error: `Missing required env variables: ${missing.join(', ')}`,
+          diagnostic: {
+            step: 'resolve_environment',
+            source,
+            runtimeEnvAvailable: !!locals?.runtime?.env,
+            expectedBindings: ['OPENROUTER_API_KEY', 'PUBLIC_SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'],
+            hint: 'Set variables/secrets in Cloudflare Pages/Workers project settings for this environment (Production/Preview).',
+            timestamp: new Date().toISOString(),
+          },
+        }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
     }
 
     const formData = await request.formData();
@@ -80,11 +98,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
     const hashBuffer = await crypto.subtle.digest('SHA-256', arrayBuffer);
     const hashHex = Array.from(new Uint8Array(hashBuffer)).map(b => b.toString(16).padStart(2, '0')).join('');
 
-    // Supabase initialization — strictly from Cloudflare runtime env
-    const supabaseUrl = env.PUBLIC_SUPABASE_URL;
-    const supabaseKey = env.SUPABASE_SERVICE_ROLE_KEY;
-
-    const supabase = createClient(supabaseUrl, supabaseKey);
+    // Supabase initialization
+    const supabase = createClient(env.PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
 
     // 3. Check Cache
     const { data: cachedResult } = await supabase
@@ -135,16 +150,15 @@ export const POST: APIRoute = async ({ request, locals }) => {
       status: 'processing'
     }).select('id').single();
 
-    // 5. Call OpenRouter API — key strictly from Cloudflare runtime env
+    // 5. Call OpenRouter API
     const base64Image = arrayBufferToBase64(arrayBuffer);
-    const openRouterKey = env.OPENROUTER_API_KEY;
 
     try {
       const aiResponse = await fetch('https://openrouter.ai/api/v1/chat/completions', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${openRouterKey}`,
+          'Authorization': `Bearer ${env.OPENROUTER_API_KEY}`,
           'HTTP-Referer': 'https://crackingwall.com',
           'X-Title': 'CrackingWall Analysis'
         },
@@ -177,7 +191,11 @@ export const POST: APIRoute = async ({ request, locals }) => {
       }
 
       if (!aiResponse.ok) {
-        throw new Error(aiData.error?.message || `AI request failed with status ${aiResponse.status}`);
+        const upstreamMessage = aiData.error?.message || `AI request failed with status ${aiResponse.status}`;
+        const normalizedMessage = aiResponse.status === 401
+          ? 'OpenRouter rejected the API key (401). Verify OPENROUTER_API_KEY in Cloudflare secrets.'
+          : upstreamMessage;
+        throw new Error(normalizedMessage);
       }
 
       if (!aiData.choices || !aiData.choices[0]) {


### PR DESCRIPTION
### Motivation
- Ensure the `/api/decode` serverless endpoint uses Cloudflare runtime bindings for secrets in production while allowing safe local fallbacks for development.
- Provide clearer diagnostics and error messages when environment bindings are missing to speed up troubleshooting.
- Update deployment instructions to document required secrets and how to store them securely in Cloudflare.

### Description
- Added a `DecodeEnv` type and implemented `resolveDecodeEnv(locals)` which prefers `locals.runtime.env` and provides optional local fallbacks in dev, returning missing keys and a `source` hint.
- Replaced strict runtime accessor with `resolveDecodeEnv` in `src/pages/api/decode.ts`, returning a JSON diagnostic error when required env variables are missing, and wiring the resolved vars to Supabase and OpenRouter calls.
- Improved AI upstream error normalization to provide a clearer message for `401` (invalid OpenRouter key) and preserved existing cache/quota/usage logic; removed prior ad-hoc runtime debug logs.
- Updated `DEPLOY.md` to require and document `PUBLIC_SUPABASE_URL`, `PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, and `OPENROUTER_API_KEY` for Cloudflare Pages/Vercel and added recommended `wrangler secret put` commands and a note that `/api/decode` expects Cloudflare runtime bindings in production.

### Testing
- Built the project and verified the serverless endpoint compiles and the updated API handler type-checks locally (`npm run build` / TypeScript compilation), with no automated unit tests added or modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d58b555df08332a0510562f8b28dd4)